### PR TITLE
Fix rendered towncrier changelog to be consistent with the way towncrier does it

### DIFF
--- a/changelog/12.bugfix.rst
+++ b/changelog/12.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed rendering to match towncrier, which means that top_line should not be included in the template.

--- a/changelog/template.rst
+++ b/changelog/template.rst
@@ -1,5 +1,5 @@
 {% if top_line %}
-{{ top_line }}
+
 {{ top_underline * ((top_line)|length)}}
 {% elif versiondata.name %}
 {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})

--- a/sphinx_changelog/towncrier.py
+++ b/sphinx_changelog/towncrier.py
@@ -112,4 +112,6 @@ def generate_changelog_for_docs(directory, skip_if_empty=True, underline=1):
     )
 
     os.chdir(curdir)
-    return rendered
+
+
+    return top_line + rendered

--- a/sphinx_changelog/towncrier.py
+++ b/sphinx_changelog/towncrier.py
@@ -113,4 +113,10 @@ def generate_changelog_for_docs(directory, skip_if_empty=True, underline=1):
 
     os.chdir(curdir)
 
-    return top_line + rendered
+    # To work around https://github.com/twisted/towncrier/issues/346 we check
+    # to see if the template is going to write the top_line, and if it isn't
+    # then we write it.
+    if "{{ top_line }}" not in template:
+        rendered = top_line + rendered
+
+    return rendered

--- a/sphinx_changelog/towncrier.py
+++ b/sphinx_changelog/towncrier.py
@@ -113,5 +113,4 @@ def generate_changelog_for_docs(directory, skip_if_empty=True, underline=1):
 
     os.chdir(curdir)
 
-
     return top_line + rendered


### PR DESCRIPTION
When running towncrier, the top_line is output before the rendered content based on the template - this means that {top_line} should not be included in the template otherwise the title appears twice. See:

* https://github.com/astropy/astropy/pull/12083

for a fix to the template in astropy core to avoid this issue. See also [this code](https://github.com/twisted/towncrier/blob/3c8a92bba0f6967d97b7fd0b05abc0cf4dc67ba4/src/towncrier/_writer.py#L41-L42) in towncrier which shows the top line is output before the rendered content.

This PR then updates sphinx-changelog to also output the top line separately from the rendered content. With this and https://github.com/astropy/astropy/pull/12083, the astropy docs finally build with no errors related to section headings for me.

This is a known issue in towncrier:

* https://github.com/twisted/towncrier/issues/346

