### PR TITLE
Fix for removed `top_line` argument in towncrier renderer

### DIFF
--- a/changelog/template.rst
+++ b/changelog/template.rst
@@ -1,12 +1,11 @@
-{% if top_line %}
-
-{{ top_underline * ((top_line)|length)}}
-{% elif versiondata.name %}
+{% if render_title %}
+{% if versiondata.name %}
 {{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
 {{ top_underline * ((versiondata.name + versiondata.version + versiondata.date)|length + 4)}}
 {% else %}
 {{ versiondata.version }} ({{ versiondata.date }})
 {{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
+{% endif %}
 {% endif %}
 {% for section, _ in sections.items() %}
 {% set underline = underlines[0] %}{% if section %}{{section}}

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
   sphinx
-  towncrier>=21.3.0
+  towncrier>=22.8.0
 
 [options.extras_require]
 all =


### PR DESCRIPTION
[Towncrier 22.8.0](https://github.com/twisted/towncrier/releases/tag/22.8.0) changed the arguments which are passed to `towncrier._builder.render_fragments` in https://github.com/twisted/towncrier/pull/303. This is a breaking change for users of this sphinx plugin as the `top_line` variable is no longer supported in custom templates, as towncrier no longer passes it into the Jinja renderer. This should not be a breaking change for packages which are using the default template.

The changes made in this PR are to let the template craft the top line itself from the package name, version number and date. However, if a custom `title_format` is configured for towncrier, this plugin will craft the top line and prepend it to the rendered changelog.

I've set the minimum Towncrier version to `22.8.0` (released yesterday) so the new `towncrier._builder.render_fragments` signature is used. If this is too big a jump, we could check the town crier version in the plugin code and support both.

This should probably be tested on sunpy and astropy before releasing.