### PR TITLE
fix for towncrier>=24.7.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
   sphinx
-  towncrier==23.11.0
+  towncrier==24.8.0
 
 [options.extras_require]
 test =

--- a/sphinx_changelog/towncrier.py
+++ b/sphinx_changelog/towncrier.py
@@ -41,9 +41,6 @@ def generate_changelog_for_docs(directory, skip_if_empty=True, underline=1):
     directory = os.path.abspath(directory)
     base_directory, config = load_config_from_options(directory, None)
 
-    curdir = os.getcwd()
-    os.chdir(base_directory)
-
     print("Loading template...")
     if isinstance(config.template, tuple):
         template = (
@@ -57,17 +54,8 @@ def generate_changelog_for_docs(directory, skip_if_empty=True, underline=1):
 
     definitions = config.types
 
-    if config.directory:
-        base_directory = os.path.abspath(config.directory)
-        fragment_directory = None
-    else:
-        base_directory = os.path.abspath(
-            os.path.join(directory, config.package_dir, config.package)
-        )
-        fragment_directory = "newsfragments"
-
     fragments, fragment_filenames = find_fragments(
-        base_directory, config.sections, fragment_directory, definitions
+        base_directory, config, strict=False
     )
 
     # Empty fragments now are an OrderedDict([('', {})])
@@ -113,8 +101,6 @@ def generate_changelog_for_docs(directory, skip_if_empty=True, underline=1):
         all_bullets=config.all_bullets,
         render_title=render_title,
     )
-
-    os.chdir(curdir)
 
     if not render_title:  # Prepend the custom title format
         top_line = config.title_format.format(


### PR DESCRIPTION
This pull-request updates `sphinx-changelog` to work with `towncrier>=24.7.0`.

As `sphinx-changelog` uses private `towncrier` functions it's liable to break for minor releases.

In this case the signature of `towncrier._builder.find_fragments` changed under-the-hood, which was the source of the issue.

Note that, `towncrier` is also now a little bit richer and can traverse up directory trees to find the configuration file and also has better `base_directory` management, and so some of the defensive code within `sphinx-changelog` melts away.

I've tested this pull-request change against building my own project, and renders its changelog as expected :+1: 

I also built the `sphinx-changelog` docs and checked the `test_changelogs` page, which appears to render fine.

I guess you want to ensure these changes are compatible with your own projects.