### PR TITLE
Mark included changelog files as dependencies, fixes #28

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
         - linux: codestyle
         - linux: build_docs
         - linux: build_docs_devtowncrier
+        - linux: build_docs_incremental
 
   notify:
     if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')

--- a/changelog/dummy
+++ b/changelog/dummy
@@ -1,0 +1,1 @@
+dummy changelog for incremental build test

--- a/changelog/dummy
+++ b/changelog/dummy
@@ -1,1 +1,0 @@
-dummy changelog for incremental build test

--- a/sphinx_changelog/directive.py
+++ b/sphinx_changelog/directive.py
@@ -50,8 +50,12 @@ class ChangeLog(SphinxDirective):
         config_path = self.get_absolute_path(config_path)
         skip_if_empty = "towncrier-skip-if-empty" in self.options
         try:
-            changelog = generate_changelog_for_docs(config_path, skip_if_empty=skip_if_empty,
-                                                    underline=self.options.get('towncrier-title-underline-index', 0))
+            changelog = generate_changelog_for_docs(
+                config_path,
+                skip_if_empty=skip_if_empty,
+                underline=self.options.get('towncrier-title-underline-index', 0),
+                build_env=self.env,
+            )
         except Exception as exc:
             raise self.severe(str(exc))
         return statemachine.string2lines(changelog, convert_whitespace=True)

--- a/sphinx_changelog/directive.py
+++ b/sphinx_changelog/directive.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from docutils import statemachine
 from docutils.parsers.rst.directives import flag, path, unchanged
 from sphinx.util.docutils import SphinxDirective
-
 from towncrier._builder import find_fragments
 from towncrier._settings import load_config_from_options
 

--- a/sphinx_changelog/directive.py
+++ b/sphinx_changelog/directive.py
@@ -1,8 +1,12 @@
+import os
 from pathlib import Path
 
 from docutils import statemachine
 from docutils.parsers.rst.directives import flag, path, unchanged
 from sphinx.util.docutils import SphinxDirective
+
+from towncrier._builder import find_fragments
+from towncrier._settings import load_config_from_options
 
 from .towncrier import generate_changelog_for_docs
 
@@ -48,6 +52,17 @@ class ChangeLog(SphinxDirective):
     def render_towncrier(self):
         config_path = self.options.get("towncrier") or "../"
         config_path = self.get_absolute_path(config_path)
+
+        # to be able to discover new fragments in incremental
+        # builds, the `env-before-read-docs` hook needs to know
+        # which documents have changelog directives using towncrier
+        # and the directory of the fragments so we register a custom
+        # dict on the sphinx build env here
+        if not hasattr(self.env, 'towncrier_docs'):
+            self.env.towncrier_docs = {}
+
+        self.env.towncrier_docs[self.env.docname] = config_path
+
         skip_if_empty = "towncrier-skip-if-empty" in self.options
         try:
             changelog = generate_changelog_for_docs(
@@ -64,6 +79,8 @@ class ChangeLog(SphinxDirective):
         changelog_filename = self.get_absolute_path(self.options['changelog_file'])
         if not changelog_filename.exists():
             raise self.severe(f"Can not find changelog file at {changelog_filename}")
+
+        self.env.note_dependency(str(changelog_filename))
         with open(changelog_filename, encoding='utf8') as fobj:
             return statemachine.string2lines(fobj.read(), convert_whitespace=True)
 
@@ -79,7 +96,45 @@ class ChangeLog(SphinxDirective):
         return []
 
 
+def trigger_changelog_rebuild(app, env, docnames):
+    """
+    Check if new fragments exist to trigger a rebuild of changelog files.
+
+    This hook is executed in the ``env-before-read-docs`` hook.
+    The directive registers documents and the towncrier config in the env
+    so we can here check for new files and in case we find new files,
+    we trigger the recreation of the documents that include the changelog
+    directive. This is done by modifying ``docnames`` inplace to add the
+    docname to it.
+    """
+    towncrier_docs = getattr(env, "towncrier_docs", None)
+    if towncrier_docs is None:
+        return
+
+    for docname, directory in towncrier_docs.items():
+        # we are rebuilding this anyway, no need to check for new fragments
+        if docname in docnames:
+            return
+
+        # find fragments
+        base_directory, config = load_config_from_options(directory, None)
+        _, fragment_filenames = find_fragments(
+            base_directory, config, strict=False
+        )
+
+        # check if any of them is not tracked yet
+        for fragment_file, _ in fragment_filenames:
+            path = os.path.abspath(fragment_file)
+
+            # we already know about this fragment
+            if path in env.dependencies[docname]:
+                continue
+
+            docnames.append(docname)
+            break
+
+
 def setup(app):
     app.add_directive('changelog', ChangeLog)
-
+    app.connect("env-before-read-docs", trigger_changelog_rebuild)
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/sphinx_changelog/towncrier.py
+++ b/sphinx_changelog/towncrier.py
@@ -5,10 +5,10 @@ changelog.
 This file is based heavily on towncrier, please see
 licenses/TOWNCRIER.rst
 """
-from pathlib import Path
 import os
 import sys
 from datetime import date
+from pathlib import Path
 
 if sys.version_info < (3, 10):
     import importlib_resources as resources
@@ -49,7 +49,6 @@ def generate_changelog_for_docs(directory, skip_if_empty=True, underline=1, buil
         template_path = Path(config.template)
 
     template = template_path.read_text()
-
 
     print("Finding news fragments...")
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,26 @@ commands =
     pip freeze
     sphinx-build -W -b html . _build/html {posargs}
 
+
+[testenv:build_docs_incremental]
+changedir = docs
+description = invoke sphinx-build to build the HTML docs
+extras = docs
+allowlist_externals =
+  grep
+  cp
+  rm
+commands =
+    pip freeze
+    sphinx-build -W -b html . _build/html {posargs}
+    grep -v 'dummy changelog for incremental build test' _build/html/test_changelogs.html
+    cp ../changelog/dummy ../changelog/999999.api.rst
+    sphinx-build -W -b html . _build/html {posargs}
+    grep 'dummy changelog for incremental build test' _build/html/test_changelogs.html
+    grep '999999' _build/html/test_changelogs.html
+commands_post =
+    rm -f ../changelog/999999.api.rst
+
 [testenv:build_docs_devtowncrier]
 changedir = docs
 description = invoke sphinx-build to build the HTML docs

--- a/tox.ini
+++ b/tox.ini
@@ -36,9 +36,9 @@ changedir = docs
 description = invoke sphinx-build to build the HTML docs
 extras = docs
 allowlist_externals =
-  grep
-  rm
-  bash
+    grep
+    rm
+    bash
 commands =
     pip freeze
     sphinx-build -W -b html . _build/html {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -37,13 +37,13 @@ description = invoke sphinx-build to build the HTML docs
 extras = docs
 allowlist_externals =
   grep
-  cp
   rm
+  bash
 commands =
     pip freeze
     sphinx-build -W -b html . _build/html {posargs}
     grep -v 'dummy changelog for incremental build test' _build/html/test_changelogs.html
-    cp ../changelog/dummy ../changelog/999999.api.rst
+    bash -c 'echo "dummy changelog for incremental build test" > ../changelog/999999.api.rst'
     sphinx-build -W -b html . _build/html {posargs}
     grep 'dummy changelog for incremental build test' _build/html/test_changelogs.html
     grep '999999' _build/html/test_changelogs.html


### PR DESCRIPTION
Thanks to ChatGPT for pointing me at the correct sphinx function with the prompt:

> Is there a way in a sphinx extension that generates rst files to invalidate the cache? I am using the extension sphinx-changelog to include towncrier based changelogs but when using sphinx-autobuild the changelog doesn't update when editing the towncrier snippets.